### PR TITLE
feat: add functionality to start a game

### DIFF
--- a/game-creation-test.http
+++ b/game-creation-test.http
@@ -1,0 +1,2 @@
+### START A GAME
+POST http://localhost:3000/games/start

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "cookie-parser": "^1.4.7",
+    "express": "^5.2.1",
+    "socket.io": "^4.8.3",
+    "uuid": "^14.0.2"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,37 @@
+const express = require('express')
+const {v4: uuidv4} = require('uuid');
+const cookieParser = require('cookie-parser');
+const app = express()
+const port = 3000;
+
+app.use(cookieParser());
+
+const games = [];
+
+function startGame(cookie) {
+    let userSessionId = uuidv4();
+    if(cookie) {
+        userSessionId = cookie;
+    }
+    const gameSessionId = uuidv4();
+    games.push({
+        gameSessionId: gameSessionId,
+        firstPlayerId: userSessionId,
+        secondPlayerId: null
+    });
+    return {userSessionId: userSessionId, gameSessionId: gameSessionId};
+}
+
+app.post('/games/start', (req, res) => {
+    let cookie = req.cookies.SESSION_ID;
+    if(cookie && games.find(game => game.firstPlayerId === cookie || game.secondPlayerId === cookie)) {
+        return res.status(409).send({error: 'Beenden Sie zuerst das andere Spiel'});
+    }
+    let game = startGame(cookie);
+    res.cookie('SESSION_ID', game.userSessionId, { httpOnly: true, maxAge: 1000 * 60 * 60, sameSite: "lax", secure: false /*Only in Development*/ });
+    res.send({gameSessionId: game.gameSessionId});
+})
+
+app.listen(port, () => {
+    console.log(`Server started on port ${port}`)
+})


### PR DESCRIPTION
I added an Endpoint for players to start a game.
The game is being persisted in RAM and the first player gets an invitation link.
Cookies are only set, when user starts a game.